### PR TITLE
Fix incorrect display of subtitle track list when using mpc-hc as player

### DIFF
--- a/src/filters/transform/vsfilter/xy_sub_filter.cpp
+++ b/src/filters/transform/vsfilter/xy_sub_filter.cpp
@@ -1111,7 +1111,7 @@ STDMETHODIMP XySubFilter::Info(long lIndex, AM_MEDIA_TYPE** ppmt, DWORD* pdwFlag
 
     int nLangs = 0;
     hr = get_LanguageCount(&nLangs);
-    CHECK_N_LOG(hr, "Failed to get option");
+    CHECK_N_LOG(hr, "Failed to get language count.");
 
     if(!(lIndex >= 0 && lIndex < nLangs+2 /* +2 fix me: support subtitle flipping */))
         return E_INVALIDARG;
@@ -1146,11 +1146,11 @@ STDMETHODIMP XySubFilter::Info(long lIndex, AM_MEDIA_TYPE** ppmt, DWORD* pdwFlag
 
     bool under_mpc_hc = (theApp.m_AppName.MakeLower().Find(_T("mpc-hc"), 0) == 0);
 
-    CStringW suffix;
+    CStringW subStreamName;
 
     if(under_mpc_hc)
     {
-        if(pdwGroup) *pdwGroup = 2;
+        if(pdwGroup) *pdwGroup = FLAG_EXTERNAL_SUB;
 
         if(i >= 0 && i < nLangs)
         {
@@ -1159,20 +1159,20 @@ STDMETHODIMP XySubFilter::Info(long lIndex, AM_MEDIA_TYPE** ppmt, DWORD* pdwFlag
             ASSERT(SUCCEEDED(hr));
             if(isEmbedded)
             {
-                suffix = _T("[Embedded (MPC-HC)]");
+                subStreamName = _T("[Embedded (MPC-HC)]");
             }
             else
             {
                 WCHAR* subName = NULL;
-                suffix = _T("[External]");
+                subStreamName = _T("[External]");
                 hr = GetSubStreamName(i, &subName);
                 if(FAILED(hr))
                 {
-                    CHECK_N_LOG(hr, "Failed to get option");
+                    CHECK_N_LOG(hr, "Failed to get substream name.");
                 }
                 else
                 {
-                    suffix.Format(_T("%s %s"), suffix.GetString(), subName);
+                    subStreamName.Format(_T("%s %s"), subStreamName.GetString(), subName);
                 }
                 if(subName) CoTaskMemFree(subName);
             }
@@ -1226,12 +1226,12 @@ STDMETHODIMP XySubFilter::Info(long lIndex, AM_MEDIA_TYPE** ppmt, DWORD* pdwFlag
         {
             if(under_mpc_hc)
             {
-                str = suffix;
+                str = subStreamName;
             }
             else 
             {
                 hr = get_LanguageName(i, ppszName);
-                CHECK_N_LOG(hr, "Failed to get option");
+                CHECK_N_LOG(hr, "Failed to get language name.");
             }
         }
         else if(i == nLangs)
@@ -2610,7 +2610,6 @@ HRESULT XySubFilter::GetSubStreamName(int iSelected, WCHAR** ppName)
     int i = iSelected;
 
     POSITION pos = m_pSubStreams.GetHeadPosition();
-    POSITION pos2 = m_fIsSubStreamEmbeded.GetHeadPosition();
     while (i >= 0 && pos)
     {
         CComPtr<ISubStream> pSubStream = m_pSubStreams.GetNext(pos);

--- a/src/filters/transform/vsfilter/xy_sub_filter.cpp
+++ b/src/filters/transform/vsfilter/xy_sub_filter.cpp
@@ -1013,7 +1013,8 @@ STDMETHODIMP XySubFilter::Count(DWORD* pcStreams)
     if(SUCCEEDED(get_LanguageCount(&nLangs)))
         (*pcStreams) += nLangs;
 
-    (*pcStreams) += 2; // enable disable force_default_style
+    if(nLangs > 0)
+        (*pcStreams) += 2; // enable disable force_default_style
 
     //fix me: support subtitle flipping
     //(*pcStreams) += 2; // normal flipped

--- a/src/filters/transform/vsfilter/xy_sub_filter.h
+++ b/src/filters/transform/vsfilter/xy_sub_filter.h
@@ -98,6 +98,7 @@ private:
     HRESULT CheckInputType(const CMediaType* pmt);
 
     HRESULT GetIsEmbeddedSubStream(int iSelected, bool *fIsEmbedded);
+    HRESULT GetSubStreamName(int iSelected, WCHAR** ppName);
 
     bool LoadExternalSubtitle(IFilterGraph* pGraph);
 

--- a/src/subtitles/STS.cpp
+++ b/src/subtitles/STS.cpp
@@ -2722,9 +2722,7 @@ bool CSimpleTextSubtitle::Open(CString fn, int CharSet, CString name)
     fn.Replace('\\', '/');
     if(name.IsEmpty())
     {
-        name = fn.Left(fn.ReverseFind('.'));
-        name = name.Mid(name.ReverseFind('/')+1);
-        name = name.Mid(name.ReverseFind('.')+1);
+        name = PathFindFileNameW(fn);
     }
 
     const wchar_t *ext = PathFindExtensionW(fn);


### PR DESCRIPTION
本来我是在[mpc-hc那里](https://github.com/clsid2/mpc-hc/pull/2352)改的，今天早上起来我又想了想，觉得还是在xySubFilter这里改可能好点。理由如下：
1. 我觉得clsid2说的没错，内置的字幕流mpc-hc已经选择好了，xySubFilter只能拿到选好的那一条。这样的话，干脆就把那一条由mpc-hc提供的名称写死。
2. 外置字幕那边，`CSimpleTextSubtitle`的`m_name`处理的似乎有问题，为了能把字幕名称完整地显示出来，我对`CSimpleTextSubtitle::Open`做了点改动。现在`m_name`存储的是字幕文件名，至于`XySubFilter::get_LanguageName`，我直接让他在拿到文件名之后再找有没有表示字幕语言的部分了。为了能在`XySubFilter::Info`里拿到`m_name`，我还在`XySubFilter::GetIsEmbeddedSubStream`下面加了一个新函数：`XySubFilter::GetSubStreamName`（不过我感觉这个函数加的不是很妥当，或许有更好的解决方法？）

最终效果如下：
![image](https://github.com/Masaiki/xy-VSFilter/assets/69719051/93c47b47-a6cc-4b51-8dd5-ab0e31401d4a)

不知道这样的改动可不可行呢？