### PR TITLE
perf: Eliminate full-bitmap alpha flipping from libass path

### DIFF
--- a/src/subtitles/RTS.cpp
+++ b/src/subtitles/RTS.cpp
@@ -3568,6 +3568,7 @@ static __forceinline void pixmix_sse2(DWORD *dst, DWORD color, DWORD alpha)
     *dst = (DWORD)_mm_cvtsi128_si32(r) + (alpha << 24);
 }
 
+template <bool InvertedAlpha>
 static __forceinline __m128i packed_pix_mix_sse2(const __m128i &dst,
     const __m128i &c_r, const __m128i &c_g, const __m128i &c_b, const __m128i &a)
 {
@@ -3589,7 +3590,12 @@ static __forceinline __m128i packed_pix_mix_sse2(const __m128i &dst,
     d_g = _mm_or_si128(d_g, c_g);
     d_b = _mm_or_si128(d_b, c_b);
 
+    __m128i ones = _mm_set1_epi32(0x1);
+    if (InvertedAlpha)
+        d_a = _mm_add_epi32(d_a, ones);
     d_a = _mm_mullo_epi16(d_a, a);
+    if (InvertedAlpha)
+        d_a = _mm_sub_epi32(d_a, ones);
     d_r = _mm_madd_epi16(d_r, a);
     d_g = _mm_madd_epi16(d_g, a);
     d_b = _mm_madd_epi16(d_b, a);
@@ -3599,10 +3605,11 @@ static __forceinline __m128i packed_pix_mix_sse2(const __m128i &dst,
     d_g = _mm_srli_epi32(d_g, 8);
     d_b = _mm_srli_epi32(d_b, 8);
 
-    __m128i ones = _mm_set1_epi32(0x1);
-    __m128i a_sub_one = _mm_srli_epi32(a, 16);
-    a_sub_one = _mm_sub_epi32(a_sub_one, ones);
-    d_a = _mm_add_epi32(d_a, a_sub_one);
+    if (!InvertedAlpha) {
+        __m128i a_sub_one = _mm_srli_epi32(a, 16);
+        a_sub_one = _mm_sub_epi32(a_sub_one, ones);
+        d_a = _mm_add_epi32(d_a, a_sub_one);
+    }
 
     d_a = _mm_slli_epi32(d_a, 24);
     d_r = _mm_slli_epi32(d_r, 16);
@@ -3613,6 +3620,7 @@ static __forceinline __m128i packed_pix_mix_sse2(const __m128i &dst,
     return _mm_or_si128(d_b, d_a);
 }
 
+template <bool InvertedAlpha>
 static __forceinline void packed_pix_mix_sse2(BYTE *dst, const BYTE *alpha, int w, DWORD color)
 {
     __m128i c_r = _mm_set1_epi32((color & 0xFF0000));
@@ -3634,10 +3642,6 @@ static __forceinline void packed_pix_mix_sse2(BYTE *dst, const BYTE *alpha, int 
         __m128i d3 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(dst + 32));
         __m128i d4 = _mm_loadu_si128(reinterpret_cast<const __m128i *>(dst + 48));
 
-        __m128i ra;
-#ifdef _DEBUG
-        ra = _mm_setzero_si128();
-#endif // _DEBUG
         __m128i a1 = _mm_unpacklo_epi8(a, zero);
         a1 = _mm_add_epi16(a1, ones);
         a1 = _mm_mullo_epi16(a1, c_a);
@@ -3650,7 +3654,7 @@ static __forceinline void packed_pix_mix_sse2(BYTE *dst, const BYTE *alpha, int 
 
         a = _mm_packus_epi16(a1, a2);
 
-        ra = _mm_cmpeq_epi32(ra, ra);
+        __m128i ra = _mm_cmpeq_epi32(zero, zero);
         ra = _mm_xor_si128(ra, a);
         a1 = _mm_unpacklo_epi8(ra, a);
         a2 = _mm_unpackhi_epi8(a1, zero);
@@ -3664,10 +3668,10 @@ static __forceinline void packed_pix_mix_sse2(BYTE *dst, const BYTE *alpha, int 
         a3 = _mm_add_epi16(a3, ones);
         a4 = _mm_add_epi16(a4, ones);
 
-        d1 = packed_pix_mix_sse2(d1, c_r, c_g, c_b, a1);
-        d2 = packed_pix_mix_sse2(d2, c_r, c_g, c_b, a2);
-        d3 = packed_pix_mix_sse2(d3, c_r, c_g, c_b, a3);
-        d4 = packed_pix_mix_sse2(d4, c_r, c_g, c_b, a4);
+        d1 = packed_pix_mix_sse2<InvertedAlpha>(d1, c_r, c_g, c_b, a1);
+        d2 = packed_pix_mix_sse2<InvertedAlpha>(d2, c_r, c_g, c_b, a2);
+        d3 = packed_pix_mix_sse2<InvertedAlpha>(d3, c_r, c_g, c_b, a3);
+        d4 = packed_pix_mix_sse2<InvertedAlpha>(d4, c_r, c_g, c_b, a4);
 
         _mm_storeu_si128(reinterpret_cast<__m128i *>(dst), d1);
         _mm_storeu_si128(reinterpret_cast<__m128i *>(dst + 16), d2);
@@ -3677,7 +3681,16 @@ static __forceinline void packed_pix_mix_sse2(BYTE *dst, const BYTE *alpha, int 
     DWORD *dst_w = reinterpret_cast<DWORD *>(dst);
     for (; alpha < alpha_end; alpha++, dst_w++)
     {
-        pixmix_sse2(dst_w, color, *alpha);
+        if (!InvertedAlpha) {
+            pixmix_sse2(dst_w, color, *alpha);
+        } else {
+            const DWORD dst_alpha = *dst_w >> 24;
+            const DWORD src_alpha = (((static_cast<DWORD>(*alpha) + 1) * (color >> 24)) >> 8);
+            pixmix_sse2(dst_w, color, *alpha);
+            const DWORD output_alpha =
+                (((dst_alpha + 1) * (0x100 - src_alpha) - 1) >> 8) << 24;
+            *dst_w = (*dst_w & 0x00FFFFFF) | output_alpha;
+        }
     }
 }
 
@@ -3922,17 +3935,12 @@ namespace
         components.swap(merged_components);
     }
 
+    template <bool Planar, bool InvertedAlpha>
     void CompositeLibassComponent(XyBitmap &bitmap,
                                   const LibassComponent &component,
                                   const std::vector<LibassTile> &tiles,
-                                  XyColorSpace color_space,
                                   XySubRenderFrameCreater &frame_creater)
     {
-        // Packed formats use the opposite alpha convention while mixing. ARGB_F keeps that
-        // convention as its output; the other packed formats are flipped back after compositing.
-        if (color_space != XY_CS_AYUV_PLANAR)
-            XyBitmap::FlipAlphaValue(bitmap.bits, bitmap.w, bitmap.h, bitmap.pitch);
-
         for (auto tile_index : component.tile_indices) {
             const ASS_Image &tile = *tiles[tile_index].image;
             const int xoff = tile.dst_x - bitmap.x;
@@ -3942,7 +3950,7 @@ namespace
 
             for (int y = 0; y < tile.h; ++y) {
                 const BYTE *alpha = tile.bitmap + y * tile.stride;
-                if (color_space == XY_CS_AYUV_PLANAR) {
+                if (Planar) {
                     const int row_offset = (yoff + y) * bitmap.pitch + xoff;
                     BYTE *dstA = bitmap.plans[0] + row_offset;
                     BYTE *dstY = bitmap.plans[1] + row_offset;
@@ -3955,13 +3963,10 @@ namespace
                 } else {
                     auto dst = reinterpret_cast<uint8_t *>(bitmap.plans[0]
                         + (yoff + y) * bitmap.pitch + xoff * 4);
-                    packed_pix_mix_sse2(dst, alpha, tile.w, color);
+                    packed_pix_mix_sse2<InvertedAlpha>(dst, alpha, tile.w, color);
                 }
             }
         }
-
-        if (color_space == XY_CS_ARGB || color_space == XY_CS_AYUV || color_space == XY_CS_AUYV)
-            XyBitmap::FlipAlphaValue(bitmap.bits, bitmap.w, bitmap.h, bitmap.pitch);
     }
 }
 
@@ -4112,10 +4117,21 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
                 const LibassComponent &component = components[component_index];
                 const RECT allocation_rect =
                     NormalizeLibassAllocationRect(component.allocation_rect, color_space);
-                XyBitmap *bitmap = render_frame_creater->CreateBitmap(allocation_rect);
+                XyBitmap *bitmap = render_frame_creater->CreateBitmap(
+                    allocation_rect, color_space != XY_CS_ARGB_F);
                 sub_render_frame->m_bitmaps.GetAt(component_index).reset(bitmap);
                 sub_render_frame->m_bitmap_ids.GetAt(component_index) = rt + component_index;
-                CompositeLibassComponent(*bitmap, component, tiles, color_space, *render_frame_creater);
+
+                if (color_space == XY_CS_AYUV_PLANAR) {
+                    CompositeLibassComponent<true, true>(
+                        *bitmap, component, tiles, *render_frame_creater);
+                } else if (color_space == XY_CS_ARGB_F) {
+                    CompositeLibassComponent<false, false>(
+                        *bitmap, component, tiles, *render_frame_creater);
+                } else {
+                    CompositeLibassComponent<false, true>(
+                        *bitmap, component, tiles, *render_frame_creater);
+                }
             }
 
             m_last_frame = sub_render_frame;
@@ -4136,14 +4152,14 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
 
         XySubRenderFrameCreater *render_frame_creater = XySubRenderFrameCreater::GetDefaultCreater();
         XySubRenderFrame *sub_render_frame = render_frame_creater->NewXySubRenderFrame(1);
-        XyBitmap *tmp = XySubRenderFrameCreater::GetDefaultCreater()->CreateBitmap(clip_rect);
+        XyBitmap *tmp = XySubRenderFrameCreater::GetDefaultCreater()->CreateBitmap(
+            clip_rect, color_space != XY_CS_ARGB_F);
         sub_render_frame->m_bitmaps.GetAt(0).reset(tmp);
         sub_render_frame->m_bitmap_ids.GetAt(0) = rt;
 
         switch (color_space)
         {
         case XY_CS_ARGB_F:
-            XyBitmap::FlipAlphaValue(tmp->bits, tmp->w, tmp->h, tmp->pitch);
             for (auto i = img; i != nullptr; i = i->next) {
                 uint32_t argb = (i->color << 24) ^ (i->color >> 8) ^ 0xFF000000;
                 argb = render_frame_creater->TransColor(argb);
@@ -4151,7 +4167,7 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
                 {
                     auto dst = reinterpret_cast<uint8_t *>(tmp->plans[0] + (i->dst_y + y - clip_rect.top) * tmp->pitch + (i->dst_x - clip_rect.left)*4);
                     auto alpha = i->bitmap + y * i->stride;
-                    packed_pix_mix_sse2(dst, alpha, i->w, argb);
+                    packed_pix_mix_sse2<false>(dst, alpha, i->w, argb);
                 }
             }
             break;
@@ -4175,7 +4191,6 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
             }
             break;
         case XY_CS_ARGB:
-            XyBitmap::FlipAlphaValue(tmp->bits, tmp->w, tmp->h, tmp->pitch);
             for (auto i = img; i != nullptr; i = i->next) {
                 uint32_t argb = (i->color << 24) ^ (i->color >> 8) ^ 0xFF000000;
                 argb = render_frame_creater->TransColor(argb);
@@ -4183,13 +4198,11 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
                 {
                     auto dst = reinterpret_cast<uint8_t *>(tmp->plans[0] + (i->dst_y + y - clip_rect.top) * tmp->pitch + (i->dst_x - clip_rect.left) * 4);
                     auto alpha = i->bitmap + y * i->stride;
-                    packed_pix_mix_sse2(dst, alpha, i->w, argb);
+                    packed_pix_mix_sse2<true>(dst, alpha, i->w, argb);
                 }
             }
-            XyBitmap::FlipAlphaValue(tmp->bits, tmp->w, tmp->h, tmp->pitch);
             break;
         case XY_CS_AYUV:
-            XyBitmap::FlipAlphaValue(tmp->bits, tmp->w, tmp->h, tmp->pitch);
             for (auto i = img; i != nullptr; i = i->next) {
                 uint32_t argb = (i->color << 24) ^ (i->color >> 8) ^ 0xFF000000;
                 uint32_t ayuv = render_frame_creater->TransColor(argb);
@@ -4197,13 +4210,11 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
                 {
                     auto dst = reinterpret_cast<uint8_t*>(tmp->plans[0] + (i->dst_y + y - clip_rect.top) * tmp->pitch + (i->dst_x - clip_rect.left) * 4);
                     auto alpha = i->bitmap + y * i->stride;
-                    packed_pix_mix_sse2(dst, alpha, i->w, ayuv);
+                    packed_pix_mix_sse2<true>(dst, alpha, i->w, ayuv);
                 }
             }
-            XyBitmap::FlipAlphaValue(tmp->bits, tmp->w, tmp->h, tmp->pitch);
             break;
         case XY_CS_AUYV:
-            XyBitmap::FlipAlphaValue(tmp->bits, tmp->w, tmp->h, tmp->pitch);
             for (auto i = img; i != nullptr; i = i->next) {
                 uint32_t argb = (i->color << 24) ^ (i->color >> 8) ^ 0xFF000000;
                 uint32_t auyv = render_frame_creater->TransColor(argb);
@@ -4211,10 +4222,9 @@ STDMETHODIMP CRenderedTextSubtitle::RenderEx( IXySubRenderFrame**subRenderFrame,
                 {
                     auto dst = reinterpret_cast<uint8_t*>(tmp->plans[0] + (i->dst_y + y - clip_rect.top) * tmp->pitch + (i->dst_x - clip_rect.left) * 4);
                     auto alpha = i->bitmap + y * i->stride;
-                    packed_pix_mix_sse2(dst, alpha, i->w, auyv);
+                    packed_pix_mix_sse2<true>(dst, alpha, i->w, auyv);
                 }
             }
-            XyBitmap::FlipAlphaValue(tmp->bits, tmp->w, tmp->h, tmp->pitch);
             break;
         }
         m_last_frame = sub_render_frame;

--- a/src/subtitles/RTS.cpp
+++ b/src/subtitles/RTS.cpp
@@ -3593,6 +3593,11 @@ static __forceinline __m128i packed_pix_mix_sse2(const __m128i &dst,
     __m128i ones = _mm_set1_epi32(0x1);
     if (InvertedAlpha)
         d_a = _mm_add_epi32(d_a, ones);
+
+    // For inverted alpha, a's low word contains 256 - src alpha. Multiplying
+    // it by the incremented destination alpha can produce 65536, which wraps
+    // to zero in this 16-bit multiply. The subtraction below still leaves the
+    // correct value in bits 8-15.
     d_a = _mm_mullo_epi16(d_a, a);
     if (InvertedAlpha)
         d_a = _mm_sub_epi32(d_a, ones);

--- a/src/subtitles/xy_bitmap.cpp
+++ b/src/subtitles/xy_bitmap.cpp
@@ -40,7 +40,8 @@ XyBitmap::~XyBitmap()
     xy_free(bits);
 }
 
-XyBitmap * XyBitmap::CreateBitmap( const CRect& target_rect, MemLayout layout )
+XyBitmap * XyBitmap::CreateBitmap( const CRect& target_rect, MemLayout layout,
+                                   bool inverted_alpha )
 {
     XyBitmap *result = DEBUG_NEW XyBitmap();
     if (result==NULL)
@@ -75,11 +76,11 @@ XyBitmap * XyBitmap::CreateBitmap( const CRect& target_rect, MemLayout layout )
         result->bits = NULL;
         break;
     }
-    ClearBitmap(result);
+    ClearBitmap(result, inverted_alpha);
     return result;
 }
 
-void XyBitmap::ClearBitmap( XyBitmap *bitmap )
+void XyBitmap::ClearBitmap( XyBitmap *bitmap, bool inverted_alpha )
 {
     if (!bitmap)
         return;
@@ -91,10 +92,11 @@ void XyBitmap::ClearBitmap( XyBitmap *bitmap )
     else
     {
         BYTE * p = bitmap->plans[0];
+        const DWORD transparent = inverted_alpha ? 0xFF000000 : 0x00000000;
         for (int i=0;i<bitmap->h;i++, p+=bitmap->pitch)
         {
-            memsetd(p, 0xFF000000, bitmap->w*4);
-        }        
+            memsetd(p, transparent, bitmap->w*4);
+        }
     }
 }
 
@@ -475,9 +477,9 @@ XySubRenderFrame* XySubRenderFrameCreater::NewXySubRenderFrame( UINT bitmap_coun
     return result;
 }
 
-XyBitmap* XySubRenderFrameCreater::CreateBitmap( const RECT& target_rect )
+XyBitmap* XySubRenderFrameCreater::CreateBitmap( const RECT& target_rect, bool inverted_alpha )
 {
-    return XyBitmap::CreateBitmap(target_rect, m_bitmap_layout);
+    return XyBitmap::CreateBitmap(target_rect, m_bitmap_layout, inverted_alpha);
 }
 
 DWORD XySubRenderFrameCreater::TransColor( DWORD argb )

--- a/src/subtitles/xy_bitmap.h
+++ b/src/subtitles/xy_bitmap.h
@@ -27,7 +27,7 @@ public:
     }
     ~XyBitmap();
 
-    static XyBitmap *CreateBitmap(const CRect& target_rect, MemLayout layout);
+    static XyBitmap *CreateBitmap(const CRect& target_rect, MemLayout layout, bool inverted_alpha = true);
 
     static void FlipAlphaValue( LPVOID pixels, int w, int h, int pitch );
     static void AlphaBltPack(SubPicDesc& spd, POINT pos, SIZE size, LPCVOID pixels, int pitch);
@@ -35,7 +35,7 @@ public:
 
     static void BltPack( SubPicDesc& spd, POINT pos, SIZE size, LPCVOID pixels, int pitch );
 private:
-    static void ClearBitmap(XyBitmap *bitmap);
+    static void ClearBitmap(XyBitmap *bitmap, bool inverted_alpha);
 };
 
 class XySubRenderFrame: public CUnknown, public IXySubRenderFrame
@@ -87,7 +87,7 @@ public:
     bool GetRgbOutputTvLevel();
 
     XySubRenderFrame* NewXySubRenderFrame(UINT bitmap_count);
-    XyBitmap* CreateBitmap(const RECT& target_rect);
+    XyBitmap* CreateBitmap(const RECT& target_rect, bool inverted_alpha = true);
     DWORD TransColor(DWORD argb);
 
     XySubRenderFrameCreater():m_xy_color_space(XY_CS_ARGB), m_bitmap_layout(XyBitmap::PACK)

--- a/test/unit_test/libass_bitmap_test.cpp
+++ b/test/unit_test/libass_bitmap_test.cpp
@@ -127,6 +127,9 @@ namespace
         CComPtr<IXySubRenderFrame> Render(REFERENCE_TIME time, int spd_type, int max_bitmap_count)
         {
             EXPECT_HRESULT_SUCCEEDED(subtitle_->SetMaxBitmapCount(max_bitmap_count));
+            // Render each requested format instead of reusing libass's cached frame from a
+            // preceding call at the same timestamp.
+            subtitle_->m_last_frame = NULL;
             CComPtr<IXySubRenderFrame> frame;
             EXPECT_HRESULT_SUCCEEDED(subtitle_->RenderEx(&frame, spd_type, kFrameRect, kFrameRect,
                                                          kFrameSize, time, kFps));
@@ -226,6 +229,101 @@ namespace
         return canvas;
     }
 
+    BYTE Div255(unsigned int value)
+    {
+        return static_cast<BYTE>((value + 1 + ((value + 1) >> 8)) >> 8);
+    }
+
+    Canvas CompositeReference(ASS_Image *images, XyColorSpace color_space)
+    {
+        const bool planar = color_space == XY_CS_AYUV_PLANAR;
+        Canvas canvas = { kFrameSize.cx, kFrameSize.cy, planar,
+                          std::vector<BYTE>(static_cast<size_t>(kFrameSize.cx) * kFrameSize.cy * 4, 0) };
+        const size_t plane_size = static_cast<size_t>(canvas.width) * canvas.height;
+
+        if (planar) {
+            std::fill(canvas.bytes.begin(), canvas.bytes.begin() + plane_size, 0xFF);
+        } else if (color_space != XY_CS_ARGB_F) {
+            for (size_t i = 3; i < canvas.bytes.size(); i += 4)
+                canvas.bytes[i] = 0xFF;
+        }
+
+        XySubRenderFrameCreater *frame_creater = XySubRenderFrameCreater::GetDefaultCreater();
+        for (ASS_Image *image = images; image; image = image->next) {
+            const DWORD argb = (image->color << 24) ^ (image->color >> 8) ^ 0xFF000000;
+            const DWORD color = frame_creater->TransColor(argb);
+            const BYTE color_a = static_cast<BYTE>(color >> 24);
+
+            for (int y = 0; y < image->h; ++y) {
+                for (int x = 0; x < image->w; ++x) {
+                    const BYTE coverage = image->bitmap[y * image->stride + x];
+                    const size_t output =
+                        static_cast<size_t>(image->dst_y + y) * canvas.width + image->dst_x + x;
+
+                    if (planar) {
+                        BYTE &dst_a = canvas.bytes[output];
+                        BYTE &dst_y = canvas.bytes[plane_size + output];
+                        BYTE &dst_u = canvas.bytes[plane_size * 2 + output];
+                        BYTE &dst_v = canvas.bytes[plane_size * 3 + output];
+                        if (x < (image->w & ~15)) {
+                            const unsigned int src_a =
+                                ((static_cast<unsigned int>(coverage) + 1) * color_a) >> 8;
+                            const unsigned int comp_a = 0x100 - src_a;
+                            const unsigned int dst_blend =
+                                ((dst_a ^ 0xFF) * comp_a + 0x80) >> 8;
+
+                            dst_a = static_cast<BYTE>(
+                                0xFF - min(src_a + dst_blend, 0xFFu));
+                            dst_y = static_cast<BYTE>(
+                                (((color >> 16) & 0xFF) * src_a + dst_y * comp_a + 0x80) >> 8);
+                            dst_u = static_cast<BYTE>(
+                                (((color >> 8) & 0xFF) * src_a + dst_u * comp_a + 0x80) >> 8);
+                            dst_v = static_cast<BYTE>(
+                                ((color & 0xFF) * src_a + dst_v * comp_a + 0x80) >> 8);
+                        } else {
+                            const BYTE src_a =
+                                Div255(static_cast<unsigned int>(coverage) * color_a);
+                            const BYTE comp_a = static_cast<BYTE>(~src_a);
+
+                            dst_a = static_cast<BYTE>(
+                                (src_a + Div255(static_cast<unsigned int>(dst_a ^ 0xFF) * comp_a))
+                                 ^ 0xFF);
+                            dst_y = Div255(((color >> 16) & 0xFF) * src_a
+                                         + static_cast<unsigned int>(dst_y) * comp_a);
+                            dst_u = Div255(((color >> 8) & 0xFF) * src_a
+                                         + static_cast<unsigned int>(dst_u) * comp_a);
+                            dst_v = Div255((color & 0xFF) * src_a
+                                         + static_cast<unsigned int>(dst_v) * comp_a);
+                        }
+                    } else {
+                        BYTE *dst = canvas.bytes.data() + output * 4;
+                        const unsigned int src_a =
+                            ((static_cast<unsigned int>(coverage) + 1) * color_a) >> 8;
+                        const unsigned int comp_a = 0x100 - src_a;
+                        const unsigned int dst_opacity =
+                            color_space == XY_CS_ARGB_F ? dst[3] : dst[3] ^ 0xFF;
+
+                        dst[0] = static_cast<BYTE>(
+                            (static_cast<unsigned int>(dst[0]) * comp_a
+                             + (color & 0xFF) * (src_a + 1)) >> 8);
+                        dst[1] = static_cast<BYTE>(
+                            (static_cast<unsigned int>(dst[1]) * comp_a
+                             + ((color >> 8) & 0xFF) * (src_a + 1)) >> 8);
+                        dst[2] = static_cast<BYTE>(
+                            (static_cast<unsigned int>(dst[2]) * comp_a
+                             + ((color >> 16) & 0xFF) * (src_a + 1)) >> 8);
+                        const BYTE output_opacity = static_cast<BYTE>(
+                            (dst_opacity * comp_a >> 8) + src_a);
+                        dst[3] = color_space == XY_CS_ARGB_F
+                            ? output_opacity
+                            : output_opacity ^ 0xFF;
+                    }
+                }
+            }
+        }
+        return canvas;
+    }
+
     void ExpectPixelEquivalent(IXySubRenderFrame *expected, IXySubRenderFrame *actual,
                                const char *format_name)
     {
@@ -234,6 +332,28 @@ namespace
         const Canvas actual_canvas = FlattenFrame(actual);
         EXPECT_EQ(expected_canvas.planar, actual_canvas.planar);
         EXPECT_EQ(expected_canvas.bytes, actual_canvas.bytes);
+    }
+}
+
+TEST_F(LibassBitmapTest, CompositeMatchesScalarReference)
+{
+    const REFERENCE_TIME time = 5000000;
+    ASSERT_GT(CountRawImages(time), 1);
+
+    for (const FormatCase &format : kFormats) {
+        SCOPED_TRACE(format.name);
+        CComPtr<IXySubRenderFrame> frame = Render(time, format.spd_type, 1);
+        const Canvas actual = FlattenFrame(frame);
+
+        int changed = 0;
+        ASS_Image *images = ass_render_frame(subtitle_->m_ass_context.m_renderer.get(),
+                                             subtitle_->m_ass_context.m_track.get(),
+                                             time / 10000, &changed);
+        ASSERT_TRUE(images != NULL);
+        const Canvas expected = CompositeReference(images, format.color_space);
+
+        EXPECT_EQ(expected.planar, actual.planar);
+        EXPECT_EQ(expected.bytes, actual.bytes);
     }
 }
 

--- a/test/unit_test/libass_bitmap_test.cpp
+++ b/test/unit_test/libass_bitmap_test.cpp
@@ -256,9 +256,15 @@ namespace
 
             for (int y = 0; y < image->h; ++y) {
                 for (int x = 0; x < image->w; ++x) {
+                    const int output_x = image->dst_x + x;
+                    const int output_y = image->dst_y + y;
+                    if (output_x < 0 || output_x >= canvas.width ||
+                        output_y < 0 || output_y >= canvas.height)
+                        continue;
+
                     const BYTE coverage = image->bitmap[y * image->stride + x];
                     const size_t output =
-                        static_cast<size_t>(image->dst_y + y) * canvas.width + image->dst_x + x;
+                        static_cast<size_t>(output_y) * canvas.width + output_x;
 
                     if (planar) {
                         BYTE &dst_a = canvas.bytes[output];


### PR DESCRIPTION
A single call to `XyBitmap::FlipAlphaValue` can take up to 4 ms when rendering a large bitmap (when targeting 4K output video resolution).

This function can be eliminated completely from the libass rendering path by initializing the bitmap's alpha value based on the color space and making some tweaks to `packed_pix_mix_sse2` also based on the color space.

This PR includes a test that ensures the output colors are still correct. The test was run before making any changes to ensure it correctly validated the original code.